### PR TITLE
misc additions to scene manager

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -92,25 +92,25 @@ stage:addChild(flipWithShadeButton)
 moveButton:addEventListener("click", 
 	function()	
 		local transition = transitions[math.random(1, 4)]
-		sceneManager:changeScene(nextScene(), 1, transition, easing.outBack) 
+		sceneManager:changeScene(nextScene(), 1, transition, easing.outBack, { eventFilter={Event.MOUSE_DOWN} } ) 
 	end)
 
 moveWithFadeButton:addEventListener("click", 
 	function()	
 		local transition = transitions[math.random(5, 8)]
-		sceneManager:changeScene(nextScene(), 1, transition, easing.outQuadratic) 
+		sceneManager:changeScene(nextScene(), 1, transition, easing.outQuadratic, { eventFilter={Event.MOUSE_DOWN} } ) 
 	end)
 
 overButton:addEventListener("click", 
 	function()	
 		local transition = transitions[math.random(9, 12)]
-		sceneManager:changeScene(nextScene(), 1, transition, easing.outBounce) 
+		sceneManager:changeScene(nextScene(), 1, transition, easing.outBounce, { userData = "outBounce" } ) 
 	end)
 
 overWithFadeButton:addEventListener("click", 
 	function()	
 		local transition = transitions[math.random(13, 16)]
-		sceneManager:changeScene(nextScene(), 1, transition, easing.outQuadratic) 
+		sceneManager:changeScene(nextScene(), 1, transition, easing.outQuadratic, { userData = "hello", eventFilter={Event.MOUSE_DOWN} } ) 
 	end)
 
 fadeButton:addEventListener("click", 

--- a/scene1.lua
+++ b/scene1.lua
@@ -1,6 +1,10 @@
 Scene1 = gideros.class(Sprite)
 
-function Scene1:init()
+function Scene1:init(t)
+	if t then
+		print("Scene1: ", t)
+	end	
+
 	self:addChild(Bitmap.new(Texture.new("gfx/scene1.jpg")))
 	
 	self:addEventListener("enterBegin", self.onTransitionInBegin, self)

--- a/scene2.lua
+++ b/scene2.lua
@@ -1,6 +1,10 @@
 Scene2 = gideros.class(Sprite)
 
-function Scene2:init()
+function Scene2:init(t)
+	if t then
+		print("Scene2: ", t)
+	end	
+
 	self:addChild(Bitmap.new(Texture.new("gfx/scene2.jpg")))
 
 	self:addEventListener("enterBegin", self.onTransitionInBegin, self)

--- a/scene3.lua
+++ b/scene3.lua
@@ -1,6 +1,10 @@
 Scene3 = gideros.class(Sprite)
 
-function Scene3:init()
+function Scene3:init(t)
+	if t then
+		print("Scene3: ", t)
+	end	
+
 	self:addChild(Bitmap.new(Texture.new("gfx/scene3.jpg")))
 
 	self:addEventListener("enterBegin", self.onTransitionInBegin, self)

--- a/scene4.lua
+++ b/scene4.lua
@@ -1,6 +1,10 @@
 Scene4 = gideros.class(Sprite)
 
-function Scene4:init()
+function Scene4:init(t)
+	if t then
+		print("Scene4: ", t)
+	end	
+
 	self:addChild(Bitmap.new(Texture.new("gfx/scene4.jpg")))
 
 	self:addEventListener("enterBegin", self.onTransitionInBegin, self)


### PR DESCRIPTION
1. Added option to SceneManager:changeScene to filter out a list of events during screen transitions
2. Added option to SceneManager:changeScene to pass user data to scene constructors
3. Moved delta addition to end of onEnterFrame so that time goes from 0 to 1 instead of (0+detlaTime) to 1
4. Added additional "real time" argument when dispatching transition events. Along with change #3, a user can now look at the additional argument to determine when a transition begins (true time=0) and when it ends (true time=1). We're using this to be able to do things like adding (removing) sprites when the transition begins (ends).
