### PR TITLE
a typo in crossFade was causing an error

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -73,9 +73,9 @@ local fadeButton = Button.new(Bitmap.new(Texture.new("gfx/fade-up.png")), Bitmap
 fadeButton:setPosition(20, 90)
 stage:addChild(fadeButton)
 
-local crossfadeButton = Button.new(Bitmap.new(Texture.new("gfx/crossfade-up.png")), Bitmap.new(Texture.new("gfx/crossfade-down.png")))
-crossfadeButton:setPosition(160, 90)
-stage:addChild(crossfadeButton)
+local crossFadeButton = Button.new(Bitmap.new(Texture.new("gfx/crossfade-up.png")), Bitmap.new(Texture.new("gfx/crossfade-down.png")))
+crossFadeButton:setPosition(160, 90)
+stage:addChild(crossFadeButton)
 
 local flipButton = Button.new(Bitmap.new(Texture.new("gfx/flip-up.png")), Bitmap.new(Texture.new("gfx/flip-down.png")))
 flipButton:setPosition(20, 130)
@@ -118,9 +118,9 @@ fadeButton:addEventListener("click",
 		sceneManager:changeScene(nextScene(), 1, SceneManager.fade, easing.linear) 
 	end)
 
-crossfadeButton:addEventListener("click", 
+crossFadeButton:addEventListener("click", 
 	function()	
-		sceneManager:changeScene(nextScene(), 1, SceneManager.crossfade, easing.linear) 
+		sceneManager:changeScene(nextScene(), 1, SceneManager.crossFade, easing.linear) 
 	end)
 
 flipButton:addEventListener("click", 

--- a/scenemanager.lua
+++ b/scenemanager.lua
@@ -167,7 +167,7 @@ function SceneManager.fade(scene1, scene2, t)
 	end
 end
 
-function SceneManager.crossfade(scene1, scene2, t)
+function SceneManager.crossFade(scene1, scene2, t)
 	scene1:setAlpha(1 - t)
 	scene2:setAlpha(t)
 end


### PR DESCRIPTION
a typo in crossFade was causing an error
classes/scenemanager.lua:105: attempt to call field 'transition' (a nil value)

The code was referring to crossfade instead of crossFade. I corrected the typo so the code runs without this error. This is minor but could be annoying.